### PR TITLE
Format code base with black

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,6 @@ environment and run it.
 (venv) $ tox
 ```
 
-> Note: The project is not yet ready to actually be formatted.
-
 To format the code automatically using `black`:
 
 ```bash


### PR DESCRIPTION
This is the result of running [`black`](https://github.com/ambv/black) via our new `tox -e fmt` command.

This removes the majority of PEP8 problems found with `tox -e pep8`. See our [Developer Guide](https://github.com/bitinerant/cleargopher#developer-guide)

I like the idea of using a standard formatter as there is no longer any ambiguity about how code should be formatted, for both maintainers and new contributors.

I skimmed over it and everything looks good to me. @bitinerant Could you confirm everything still works properly with this branch?